### PR TITLE
Fix routing issues by removing baseURL override

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -48,8 +48,7 @@ jobs:
         run: |
           hugo \
             --gc \
-            --minify \
-            --baseURL "${{ steps.pages.outputs.base_url }}/"          
+            --minify          
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
Fixes routing failures for /posts/, /about/, and the home page by removing the baseURL override that was forcing Hugo to use the GitHub Pages default URL instead of the configured custom domain.

The --baseURL parameter in the Hugo build was overriding the baseURL from hugo.toml, causing all routes to resolve incorrectly on stefanchristensen.me. Removing this override allows Hugo to use the configured baseURL and fixes routing for all pages.

Fixes #0