### PR TITLE
Rewrite homepage to emphasize company building expertise

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -2,10 +2,14 @@
 title: "Stefan Christensen"
 ---
 
-Physicist turned fintech leader. I build platforms, scale organizations, and help people do their best work.
+I build the systems that turn complexity into advantage. Whether it's organizational structure, scaling teams, payments infrastructure, or technical systems - I create the foundations that let companies move fast as they grow.
 
-Currently SVP at [Pleo](https://www.pleo.io), where I've spent the last five years scaling the company from 100 to 850+ people across payments, platform, and engineering.
+Currently SVP at [Pleo](https://www.pleo.io), where I've spent five years scaling the platform organization from 100 to 850+ people. We turned payments infrastructure into a competitive moat.
 
-Before that: McKinsey consultant, quantum physicist, and occasional atomic clock builder.
+Before that: McKinsey consultant focused on financial institutions, and a PhD physicist who built atomic clocks.
 
 Read more [about me](/about/) or check out my [experience](/experience/).
+
+---
+
+Let's connect: [LinkedIn](#) [Twitter](#)

--- a/content/_index.md
+++ b/content/_index.md
@@ -12,4 +12,4 @@ Read more [about me](/about/) or check out my [experience](/experience/).
 
 ---
 
-Let's connect: [LinkedIn](#) [Twitter](#)
+Let's connect: [LinkedIn](https://www.linkedin.com/in/stefanlchristensen/)

--- a/docs/plans/2026-02-02-homepage-rewrite-design.md
+++ b/docs/plans/2026-02-02-homepage-rewrite-design.md
@@ -1,0 +1,79 @@
+# Homepage Rewrite Design
+
+**Date:** 2026-02-02
+**Status:** Approved
+
+## Objective
+
+Rewrite the stefanchristensen.me homepage to position Stefan as a company builder/transformation leader with deep fintech/payments expertise, making it clear to recruiters and employers why they should care within 10 seconds.
+
+## Problem Statement
+
+Current homepage is too generic:
+- Doesn't lead with company building/transformation expertise
+- Doesn't mention specific domain expertise (payments, fintech)
+- Generic tagline doesn't differentiate or create interest
+- No clear invitation to connect
+
+## Design Decisions
+
+### 1. Positioning Strategy
+
+**Primary:** Company building and scaling
+**Credibility anchor:** Deep fintech/payments expertise at Pleo
+
+**Core thesis:** "I turn complexity into advantage"
+**Scope of complexity:** Organizational structure, scaling teams, payments infrastructure, technical systems
+
+### 2. Voice and Tone
+
+**Style:** Builder identity - direct, confident, operator energy
+**Opening:** Lead with what you do, not who you are
+**Evidence:** Pleo as transformation story (100→850+ people, platform org, competitive moat)
+
+### 3. Content Structure
+
+**Opening paragraph:**
+- Lead with builder identity and core thesis
+- Enumerate types of complexity in natural order (people/org → tech/payments)
+- Establish foundations/speed theme
+
+**Proof paragraph:**
+- Pleo experience framed as "platform organization" scaling
+- Add "competitive moat" language to show transformation
+- Keep timeframe (5 years) and scale (100→850+)
+
+**Background paragraph:**
+- Keep McKinsey + physicist arc
+- Add "financial institutions" context to McKinsey
+- Maintain personality ("atomic clocks")
+
+**Navigation:**
+- Keep existing About/Experience links
+
+**Contact section:**
+- Minimal and direct: "Let's connect: [LinkedIn] [Twitter]"
+- Horizontal rule for separation
+- Placeholder links for user to fill in
+
+## Implementation
+
+**File to edit:** `content/_index.md`
+
+**Changes:**
+1. Replace opening tagline with builder identity statement
+2. Reframe Pleo paragraph to emphasize platform org + competitive advantage
+3. Add financial institutions context to McKinsey line
+4. Add contact section after navigation links
+
+## Success Criteria
+
+A recruiter or potential employer scanning the homepage for 10 seconds should understand:
+- Stefan is a company builder/transformation leader (not just a fintech person)
+- He has deep expertise in payments/fintech as proof
+- He scales teams, organizations, and technical systems
+- He's open to connecting
+
+## Full Content
+
+See implementation in `content/_index.md`


### PR DESCRIPTION
## Summary
Repositioned the homepage to lead with company building and transformation expertise, using fintech/payments as the credibility anchor. The new headline emphasizes turning organizational, people, technical, and domain complexity into competitive advantage.

## Changes
- New opening establishes builder identity and core thesis
- Reframed Pleo experience as platform organization scaling
- Added "competitive moat" language to show impact
- Added financial institutions context to McKinsey background
- Added minimal contact section with social links

This positions Stefan for company building/transformation roles while maintaining the terminal aesthetic and minimal design.

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>