### PR TITLE
Add blog posts on platform engineering approach

### DIFF
--- a/_drafts/enabling-to-product-org-change.md
+++ b/_drafts/enabling-to-product-org-change.md
@@ -1,0 +1,144 @@
+---
+layout: post
+title: "Reorganizing from Enablement to Product-Focused Platform Teams"
+date: 2026-02-03
+categories: org-structure, platform-engineering
+status: draft
+---
+
+# Reorganizing from Enablement to Product-Focused Platform Teams
+
+Organizational restructuring is hard. It disrupts relationships, creates uncertainty, and almost always generates anxiety. But sometimes the structure itself is the problem, and no amount of process improvement will fix it.
+
+When we transitioned from an enablement-focused platform organization to a product-focused one, we weren't creating new teams—we were reframing their purpose. And that reframing mattered far more than we expected.
+
+## Why the Old Structure Didn't Work
+
+The original platform organization was structured around "enablement." The mandate was straightforward: help the product teams build faster. Provide tools, documentation, guidance, and support.
+
+In practice, this created a few problems:
+
+**1. No clear success metric**
+If you're "enabling" teams, how do you know you've succeeded? Did you provide enough options? Is it the right documentation? Are teams happy? These are vague. Teams optimized for what felt like activity—writing more guides, offering more choices, providing more options.
+
+**2. Diffuse accountability**
+When your job is to "enable," there's no clear end state. You're successful if teams say they're enabled. But teams often don't know what they need until they try to do the work. So platform teams were always one step behind.
+
+**3. Low agency for platform engineers**
+Platform team members were frustrated. Many joined to write code and build infrastructure, not maintain documentation or run workshops. The lack of concrete products meant the work felt abstract and endless.
+
+**4. Invisible impact**
+When your work is "enablement," it's hard to point to what you built. You wrote documentation (thousands of lines). You answered questions (hundreds). You helped ship features (indirectly). But none of this felt concrete.
+
+## The Reframe: Platform as Product
+
+The transition started with a different framing: **platform teams own products, not processes.**
+
+A product has:
+- **Users**: Specific teams or engineers who use it
+- **Clear value**: "Using this, you can X, and you get Y for free"
+- **Iteration**: Based on feedback, you improve the product
+- **Accountability**: Did the product solve the problem?
+
+This wasn't a reorganization that changed who reported to whom. It was a reframing that changed how we thought about the work.
+
+## What Changed Structurally
+
+The organizational structure actually *looked* similar before and after. But the internal logic was different:
+
+**Before**: Individual teams working on "developer enablement"
+- WebCore (developer productivity)
+- Mobile infrastructure
+- DevEx
+- Infrastructure
+
+**After**: Individual teams owning platform products
+- WebCore (frontend platform as a product for web engineers)
+- Mobile Core (mobile platform as a product for iOS/Android engineers)
+- DevX (developer experience infrastructure as a product for all engineers)
+- Backend Core (backend infrastructure as a product for backend engineers)
+
+The teams themselves barely changed. But the question each team asked shifted from "How do we help people build?" to "What product do we own that helps people build?"
+
+## The Leadership Layer
+
+One structural change was significant: **we put a product-focused leader in charge.**
+
+This person's mandate was different from a traditional infrastructure lead:
+- Think about these platforms like products
+- Do user research (talk to engineers, observe their workflows)
+- Make decisions about prioritization based on impact, not requests
+- Own the customer experience, not just the technical implementation
+- Iterate based on feedback
+
+This role required someone with product thinking, who could bridge between deep technical understanding and user empathy. It's a challenging role to hire for, because it's not quite a traditional product manager (those are often less technical) and not quite a technical leader (those often skip user research).
+
+## Managing the Transition
+
+The actual transition had a few key phases:
+
+**Phase 1: Reframing (month 1-2)**
+Clear communication about what was changing and why. This wasn't "your job is now different"—it was "our platform is becoming a product, and that changes how we work."
+
+**Phase 2: Getting Specific (month 2-3)**
+Each team articulated what their product was. Not vague ("developer enablement") but concrete ("the web framework that handles routing, state management, and deployment, giving teams X for free").
+
+**Phase 3: User Research (month 3-6)**
+Teams actually talked to engineers. What frustrated them? What slow them down? What could we solve? This was uncomfortable for some teams that had been operating in abstract space.
+
+**Phase 4: Roadmap Shift (month 6+)**
+Based on research, teams created roadmaps focused on their specific product. This meant saying "no" to things that didn't fit the product vision. It was liberating for some teams, unsettling for others.
+
+## What Worked
+
+**Clarity**: Teams knew what they owned. This was surprisingly powerful. Instead of "help people build," the mandate was "own the mobile platform, and measure success by whether teams can ship faster, more reliably."
+
+**Agency**: Platform engineers could actually build things. Not maintain documentation—build products. This attracted different people and motivated the existing team.
+
+**Impact visibility**: Instead of abstract "enablement," teams could point to concrete outcomes. "We shipped the deployment tool. Teams using it reduced deployment time by 40%. We're now working on X."
+
+**User focus**: Talking to actual engineers changed what teams worked on. Instead of guessing what people needed, they knew. This shifted roadmaps significantly.
+
+## What Was Hard
+
+**Saying no**: Being product-focused means having a point of view. Not every request gets fulfilled. This was uncomfortable for teams used to "the best answer is maximum optionality."
+
+**Resisting feature creep**: Once you're shipping a product, you get requests. Lots of them. Saying no to requests—even good ones—is hard. But every feature adds complexity and maintenance burden.
+
+**Finding the right product leaders**: This role doesn't have a clear career ladder in most organizations. We had to create it as we went, which meant some experimentation and some misfires.
+
+**Moving fast in a structured way**: Being product-focused also means thinking about consistency, compatibility, documentation, and long-term maintainability. This can slow down teams used to just shipping.
+
+## The Outcome
+
+Six months after the transition, the shift was visible:
+
+- Teams were shipping more often
+- Feature adoption was higher (because features were designed with users, not guessed at)
+- Platform engineers reported higher job satisfaction (they were building, not just supporting)
+- Product teams were moving faster (because the platforms actually solved their problems, rather than offering options)
+
+The reframing didn't require new hiring, new budgets, or major structural changes. It required a shift in how we thought about the work and who we hired to lead it.
+
+## Key Lessons
+
+**1. Structure reflects and reinforces how you think**
+An "enablement-focused" structure encourages abstract thinking. A "product-focused" structure encourages specific thinking.
+
+**2. The leadership mandate matters**
+Put someone in charge who thinks like a product leader. This person's decision-making will shape the entire platform.
+
+**3. User research is non-negotiable**
+You can't be product-focused without understanding your users. This means embedding, interviewing, observing—not just asking.
+
+**4. Platform teams need agency**
+If you're asking teams to own products, they need the autonomy to say no to requests and pursue their product vision. Give them that.
+
+**5. Product doesn't mean perfect**
+Platform products don't need to be flawless. They need to be clear, useful, and iterable. Done and useful beats perfect and delayed.
+
+## Conclusion
+
+Reorganizing from enablement to product wasn't a top-down restructuring. It was a shift in how we framed the work, combined with the right leadership to make that framing real. It required discipline—saying no, staying focused, doing user research—but it unlocked a different kind of organization.
+
+If your platform teams are stuck in abstractions, constantly overextended, or struggling with unclear success metrics, it might be time to ask: What if these teams owned products instead of enabling people? What would change?

--- a/_drafts/measuring-platform-maturity.md
+++ b/_drafts/measuring-platform-maturity.md
@@ -1,0 +1,132 @@
+---
+layout: post
+title: "Measuring Platform Maturity Without OKR Percentage Games"
+date: 2026-02-03
+categories: metrics, platform-engineering, team-performance
+status: draft
+---
+
+# Measuring Platform Maturity Without OKR Percentage Games
+
+The question seemed simple at first: How do you measure whether a platform organization is maturing and improving?
+
+The obvious answer was OKRs. Set objectives, measure key results, track progress. Agile, data-driven, modern.
+
+But about halfway through the first quarter, we realized the metrics were creating exactly the wrong incentives.
+
+## The OKR Percentage Problem
+
+When you track "percentage of OKR completed," you get a specific set of behaviors:
+
+**Optimism incentive**: If you're 40% through the quarter and only 20% done with an OKR, there's pressure to claim you're on track. You've got six weeks. You'll figure it out. The reporting mechanism becomes a forecast, and forecasts get padded.
+
+**Granularity gaming**: One way to show progress is to break things into smaller pieces. Instead of "ship payment infrastructure," you ship "authentication component" and "ledger component" separately. On the OKR dashboard, this looks like progress. In reality, you're just subdividing work more finely.
+
+**Sandbagging and heroics**: If you're 100% done with an OKR with two weeks left, there's no incentive to improve the thing. You're done. But if you're struggling to hit a deadline, you can pull an all-nighter and heroically finish. The metric rewards crisis behavior.
+
+**Risk aversion**: If you're 50% toward an ambitious goal and there's significant uncertainty about the remaining 50%, what do you do? Many teams reduce scope to guarantee completion. The metric rewards conservative estimates.
+
+**Divorce from impact**: You can hit 100% of your OKR and still fail to improve the thing you were trying to improve. The metric is about completion, not about outcomes.
+
+## What We Changed
+
+Instead of tracking "percentage complete," we shifted to tracking **confidence levels**.
+
+The question changed from: "How much of this OKR have you completed?" to "How confident are you that you'll complete this by the end of the quarter?"
+
+The confidence question creates different incentives:
+
+**Honesty**: If you're not confident, you say so. You're not being evaluated on whether you succeeded yet. You're being evaluated on whether your assessment is realistic.
+
+**Early problem-solving**: If you're currently 60% done and you're only 40% confident about the remaining 40%, that signals a problem. Now the conversation shifts to: What's the dependency? What's the technical complexity? What do you need to become more confident?
+
+**Scope visibility**: Confidence goes down when scope is unclear, dependencies are hidden, or risks are unmitigated. The metric makes these problems visible.
+
+**Sustainable pace**: You can't just throw more hours at a problem to game a confidence metric the way you can with a completion percentage. Confidence reflects actual risk, not effort.
+
+**Realistic planning**: Teams learn to make better estimates because they're accountable for assessing confidence, not just completing work.
+
+## Building the Maturity Framework
+
+Beyond OKRs, we needed a way to assess platform maturity more broadly. This became a scorecard that articulated what we cared about as a platform organization.
+
+The scorecard had several dimensions:
+
+**Practical Health & Support**
+Foundational elements. Do we have enough people managers? Is there sufficient mentorship and care? Are teams stable, or are we burning people out?
+
+**Motivated Individuals in High-Performing Teams**
+Engagement and capability. Are people motivated? Are they learning? Are teams collaborating well, or are silos forming?
+
+**Leadership as a Team Sport**
+How we operate as a leadership group. Is decision-making distributed or bottlenecked? Do we actually support each other, or are we in competition?
+
+**High Expectations with Support**
+The balance between rigor and help. We set high bars. But we're there to help teams meet them. This isn't "strict," it's "rigorous and supportive."
+
+## How the Scorecard Works
+
+Rather than percentage completion or numeric scores, the scorecard used a **progress indicator** for each dimension, assessed quarterly.
+
+For each dimension, we asked: Are we improving? Are we stable? Are we regressing?
+
+Specific questions:
+- **Practical Health**: Do we have coverage of people managers? Are they spending time on mentorship? Is turnover acceptable? Are there obvious signs of burnout?
+- **Motivated Teams**: Are engineers excited about their work? Are teams shipping things? Are there blocked or frustrated sub-teams?
+- **Leadership Team**: Are decisions made quickly? Is credit shared? Are conflicts resolved constructively?
+- **High Expectations**: Are we pushing for improvement? Are teams supported when they struggle?
+
+Each quarter, each dimension would be assessed as:
+- Improving (green)
+- Stable (yellow)
+- Regressing (red)
+
+## Why This Works Better
+
+**It removes gaming**: You can't game "are we improving?" You can game "did we hit the number?" The moment you shift from numeric targets to qualitative assessment, the incentive structure changes.
+
+**It surfaced structural issues**: When "leadership as team sport" was regressing, that didn't mean someone was lazy. It meant we had structural problems—unclear decision rights, bottlenecks, lack of trust. The metric made the problem visible so we could address it.
+
+**It acknowledged uncertainty**: Some things are hard to measure. Instead of creating false precision ("we're 73% confident"), the framework acknowledged that judgment and qualitative assessment are legitimate tools.
+
+**It tracked leading indicators**: "Are we improving?" is a leading indicator. "Did we complete?" is a lagging indicator. Leading indicators let you course-correct mid-quarter.
+
+**It forced conversation**: OKR percentage completion can be assessed by a dashboard. The maturity scorecard required conversation. What does "improving" look like? Are we being honest about regression? This forced alignment.
+
+## Common Misconceptions
+
+**"This is less rigorous than numbers"**
+Actually, it's more rigorous. Numbers give false precision. "We're 67% done" feels more rigorous than "we're on track but facing risks," but the former is often less honest. The latter requires you to actually think about what's happening.
+
+**"You need both"**
+Some organizations try to do confidence-based OKRs *and* have numeric scorecards. This usually doesn't work. The confidence-based approach requires a fundamentally different mindset. Adding numeric targets on top reintroduces the gaming.
+
+**"This is soft leadership"**
+The opposite. This framework was used to have hard conversations. If a dimension is regressing, that's a signal to investigate and act. The conversation is tougher than "we didn't hit the target," because it requires understanding why and committing to change.
+
+## What Didn't Work
+
+**Not reviewing the framework itself**
+We set up the scorecard and treated it as fixed. After two quarters, some dimensions weren't useful anymore. The framework itself needs to iterate.
+
+**Letting it become a compliance exercise**
+If leadership just rubber-stamps the assessments quarterly without actually discussing them, it becomes theater. The value is in the conversation, not the categorization.
+
+**Not acting on regression signals**
+If something shows red consistently and no one addresses it, the entire framework becomes meaningless. Signal requires response.
+
+## Conclusion
+
+The shift from OKR percentage completion to confidence-based OKRs and maturity scorecards fundamentally changed how the platform organization operated.
+
+It wasn't about rejecting metrics or data. It was about using metrics and data to drive the right conversations and behaviors, rather than creating perverse incentives.
+
+The key insight: **The structure of how you measure shapes the behavior of the people being measured.**
+
+OKR percentages incentivize completion over impact, estimates over honesty, and individual heroics over systemic improvement.
+
+Confidence-based approaches and maturity frameworks incentivize realistic assessment, early problem-solving, and sustainable pace.
+
+If you're running a platform organization and you're frustrated with how OKRs are playing out—teams sandbagging, metrics divorcing from reality, people stressed about hitting targets—consider: What if you measured something different?
+
+Not something softer. Something more honest.

--- a/_drafts/platform-engineering-approach.md
+++ b/_drafts/platform-engineering-approach.md
@@ -1,0 +1,109 @@
+---
+layout: post
+title: "From Enablement to Products: Implementing Platform Engineering at Scale"
+date: 2026-02-03
+categories: platform-engineering
+status: draft
+---
+
+# From Enablement to Products: Implementing Platform Engineering at Scale
+
+When internal platform teams focus on providing maximum optionality—every choice, every configuration, every possible path—something paradoxical happens. Engineers drown in choices. Documentation sprawls. The platform teams themselves burn out writing process guides instead of shipping code. And somehow, everyone feels like they're drowning.
+
+This was the starting point for reimagining platform engineering: moving from an enablement model that offered everything, to a product model that offered something specific and genuinely useful.
+
+## The Problem with "Maximum Optionality"
+
+Traditional platform enablement teams face a genuine tension. They want to empower product teams. They want to avoid dictating solutions. So they try to offer maximum flexibility—every tool, every option, every possible configuration.
+
+The results are predictable:
+
+- **Sprawl**: Documentation balloons. Teams maintain extensive guides for dozens of alternatives, none of which are cohesive.
+- **Decision fatigue**: Product teams face endless choices with little guidance on what actually works.
+- **Distraction**: Platform teams spend cycles writing documentation instead of understanding customer needs. They lose touch with what's actually frustrating their users.
+- **False satisfaction**: Everyone appears busy, but throughput doesn't improve. The system feels heavy.
+
+The fundamental mistake is treating the platform as a service that should minimize constraints, rather than a service that should maximize value.
+
+## The Shift: Platform as Product
+
+The breakthrough came from a simple reframing: **platform teams should own products, not processes.**
+
+This means:
+
+1. **Sensible defaults over maximum optionality** - If there's no compelling reason not to do something a particular way, do it that way. You get monitoring, alerting, logging, scaling, and observability for free.
+
+2. **Opinionated paths instead of open-ended choices** - The "golden path" isn't a limitation. It's the fastest, most reliable way to accomplish the task. Teams can deviate, but deviating is a decision, not the default.
+
+3. **Active buy vs. build decisions** - Instead of building everything internally, evaluate what genuinely needs to be custom versus what should be purchased or integrated. Many organizations inherit a "build everything" mentality from their startup phase, but that doesn't scale.
+
+This product-focused approach requires a shift in mindset. It means saying "no" to some requests. It means being willing to have opinions. And it means staying close to your users—the engineers and product managers using your platform—to understand what actually helps them move faster.
+
+## Six Principles for Platform Products
+
+To guide this shift, we anchored the platform work in six principles:
+
+**1. Build for Humans**
+This sounds simple but isn't. It means understanding the actual workflows of your users. How do engineers onboard? What frustrates them? What could be smoother? It requires talking to users, embedding in teams, observing their work.
+
+**2. Focus on Impact (Outcome > Output)**
+Measure what matters: Did the change help teams move faster? Did it reduce toil? Did it improve reliability? Not: How many features did we ship?
+
+**3. Build API-First**
+Whether internal tools or infrastructure, design for programmatic access first. This enables other teams to build on top of what you've created. It removes bottlenecks where teams have to wait for manual steps.
+
+**4. Make Quality Your Business**
+Quality isn't something that happens after launch. It's foundational. Tests, observability, monitoring, alerting—these aren't afterthoughts. They're part of what the platform provides for free.
+
+**5. Treat Data as a Product**
+Data that's locked in one system has limited value. Data that's accessible, documented, and discoverable becomes a platform resource. This applies to metrics, logs, events, and structured data alike.
+
+**6. Think Safe & Secure**
+Regulatory requirements, security posture, compliance—these aren't constraints imposed on the platform. They're core to what the platform enables. Teams should be able to build fast *and* safely.
+
+## From Documentation to Implementation
+
+Articulating these principles was a necessary first step. But principles without implementation are just words.
+
+The platform teams created a "How We Build Things" database—essentially a collection of the sensible defaults, golden paths, and best practices, organized around concrete tasks. Instead of generic principles, it documented: "To deploy a service, do X. You get Y for free."
+
+These weren't prescriptive documents trying to cover every edge case. They were products—actual tools, templates, and infrastructure—that implemented the sensible defaults. The documentation explained what you got and why.
+
+The shift from "tell teams how to do things" to "give teams tooling that does the right thing by default" was profound. It meant engineers could adopt the path by simply using the tool, rather than reading extensive documentation and hoping they implemented it correctly.
+
+## Measuring What Matters
+
+How do you know this approach is working? The obvious metrics are throughput and speed:
+
+- **Throughput**: Work completed increased significantly. More PRs shipped. More features deployed.
+- **Cycle time**: Time from idea to production compressed. Average cycle times dropped from over 5 days to around 3 days, with fewer spikes.
+
+But these metrics alone don't tell the full story. The more important signal was that platform teams stopped being a bottleneck. Product teams could move forward independently. Questions got answered. Decisions happened faster. The platform teams weren't context-switching between dozens of enablement requests—they were focused on products that genuinely helped.
+
+## What Worked
+
+- **Product thinking**: Staying close to users, understanding their needs, iterating on solutions based on feedback.
+- **User research**: Even informal—embedding in teams, observing work, doing interviews. Small user populations mean you can do high-touch research.
+- **Sensible defaults with free benefits**: "Do it this way and you get monitoring, alerting, logging, scaling for free" is more powerful than "here are all your options."
+- **Building for concrete needs first, then generalizing**: Start with a specific, real problem. Solve it well. Then abstract the solution.
+- **One clear entry point**: Instead of teams having to figure out which sub-team owns what, create one "front door" and let the platform figure out routing internally.
+
+## What Didn't Work
+
+- **Traditional product management approaches**: Techniques designed for external products with millions of users don't transfer well to internal platforms serving hundreds of engineers. A/B testing, statistical significance, complex experiments—these aren't the right tools for small user populations.
+- **Enablement mentality creeping back in**: It's easy to slip back into "define it and they will obey" thinking. They won't. Compliance through documentation is weak. Compliance through tooling that makes the right thing the easy thing is strong.
+- **Tracking % completion of OKRs**: Moving away from "how much of the OKR did we complete?" to "how confident are we that we'll complete this by end of quarter?" changed the conversation from arguments about estimation to discussions about dependencies and risk.
+
+## Conclusion
+
+Platform engineering isn't about having the most sophisticated tools or the most options. It's about understanding what your internal customers actually need and building products that help them move faster and with more confidence.
+
+The shift from enablement to product doesn't happen overnight. It requires:
+
+- Staying close to your users
+- Being willing to have opinions
+- Building implementation before writing documentation
+- Measuring impact, not output
+- Iterating based on feedback
+
+When you get it right, the platform becomes invisible in the best way—teams stop thinking about it and start thinking about what they're building.

--- a/_drafts/support-meetings-over-status.md
+++ b/_drafts/support-meetings-over-status.md
@@ -1,0 +1,97 @@
+---
+layout: post
+title: "Support Meetings, Not Status Meetings: How Naming Changes Culture"
+date: 2026-02-03
+categories: team-dynamics, leadership
+status: draft
+---
+
+# Support Meetings, Not Status Meetings: How Naming Changes Culture
+
+There's a subtle but profound difference between a "status meeting" and a "support meeting."
+
+In a status meeting, the implicit message is: *Report on what you've done. Explain your progress. Account for your time.*
+
+The dynamic that emerges is predictable. Teams prepare updates. Managers listen for problems. If something's stuck, the conversation becomes defensive—explaining why, justifying timeline slips, and so on.
+
+In a support meeting, the implicit message is different: *Come tell us what you need. Let us help remove obstacles. We're here to support your work.*
+
+That shift in framing—from "report to us" to "let us help you"—changes everything about how the conversation happens.
+
+## Why Naming Matters
+
+Our language shapes how we think. Military organizations call them "stand-ups" (temporary, quick). Agile teams use "daily syncs." Corporate environments use "status checks."
+
+Each term carries assumptions. And those assumptions shape behavior.
+
+When you call something a "status meeting," you're establishing a reporting hierarchy. The team is providing information. The leadership is consuming it. That's the frame.
+
+When you call something a "support meeting," you're establishing a helping relationship. The team is stating needs. The leadership is problem-solving alongside them.
+
+The difference might seem semantic. It's not.
+
+## What Changes
+
+In practice, support meetings create different conditions:
+
+**For the team:**
+- Less defensive energy around explaining delays or challenges
+- More openness about blocked work, unclear requirements, or architectural decisions that are slowing progress
+- Feeling like they have agency to ask for what they need
+
+**For the leadership:**
+- Shift from "monitoring" to "removing obstacles"
+- Different questions: "What's blocking you?" instead of "Why isn't this done?"
+- Better visibility into structural problems (unclear requirements, resource constraints, technical debt) rather than just execution updates
+
+**For the relationship:**
+- Collaborative rather than hierarchical framing
+- Mutual accountability: leadership is accountable for creating conditions for success; teams are accountable for identifying what's needed
+
+## Making It Real
+
+Changing the name is necessary but not sufficient. The framing only works if leadership actually behaves like they're there to help.
+
+This means:
+
+- **Asking good questions**: "What's blocking you?" not "Why is this late?"
+- **Following up**: If a team identifies an obstacle, leadership actually removes it or explains why they can't.
+- **Not using the meeting as surveillance**: The goal isn't to catch problems. It's to surface them early so they can be solved.
+- **Making decisions quickly**: Teams raise concerns; leadership responds with decisions or clear next steps, not "let me think about it and get back to you."
+
+If leadership uses "support meetings" as a cover for the same old monitoring—just with softer language—the naming change will feel like manipulation. And it will be.
+
+But when the framing genuinely represents the intent, it transforms how teams engage with their leadership.
+
+## The Deeper Pattern
+
+This is part of a larger insight: **the words we use in organizational structures shape the relationships that form.**
+
+Other examples:
+- "Unblock" implies obstacles to be removed. "Unblock" implies agency.
+- "Help" implies collaborative problem-solving. "Support" does too.
+- "Standup" implies brief and temporary. "Meeting" implies more formal and scheduled.
+
+Organizations that pay attention to language tend to have healthier communication patterns. Not because language controls behavior directly, but because it shapes the frame through which people interpret what's happening.
+
+## When This Breaks Down
+
+The support meeting framing can break down in a few ways:
+
+**If teams stop being honest**: If they learn that surfacing problems gets them blamed rather than helped, they'll stop surfacing them. Then you're back to discovery through dysfunction.
+
+**If leadership is too busy to actually help**: If teams raise obstacles and nothing changes, the message is: "This is called a support meeting, but we're not actually going to support you." The framing becomes cynical.
+
+**If it becomes a tool for blame**: "We said we'd support you, so your failure to deliver is on you." The framing becomes weaponized.
+
+These failures happen when the intent behind the naming isn't genuine. And that comes down to leadership choices about how much energy they invest in actually removing obstacles.
+
+## Conclusion
+
+Language is a lever. It's not the only thing that matters, but it matters more than we often acknowledge.
+
+Renaming status meetings to support meetings is a simple change that can shift the entire dynamic of how leadership and teams interact. But it only works when the actual behavior matches the frame.
+
+The question isn't "Should we call them support meetings instead of status meetings?" The question is: "Do we actually want to support the teams doing the work, and are we willing to structure the conversation around that?"
+
+If the answer is yes, the naming change makes sense. If the answer is no, the naming change is just theater.

--- a/_posts/2026-02-03-platform-engineering-approach.md
+++ b/_posts/2026-02-03-platform-engineering-approach.md
@@ -1,0 +1,108 @@
+---
+layout: post
+title: "From Enablement to Products: Implementing Platform Engineering at Scale"
+date: 2026-02-03
+categories: platform-engineering
+---
+
+# From Enablement to Products: Implementing Platform Engineering at Scale
+
+When internal platform teams focus on providing maximum optionality—every choice, every configuration, every possible path—something paradoxical happens. Engineers drown in choices. Documentation sprawls. The platform teams themselves burn out writing process guides instead of shipping code. And somehow, everyone feels like they're drowning.
+
+This was the starting point for reimagining platform engineering: moving from an enablement model that offered everything, to a product model that offered something specific and genuinely useful.
+
+## The Problem with "Maximum Optionality"
+
+Traditional platform enablement teams face a genuine tension. They want to empower product teams. They want to avoid dictating solutions. So they try to offer maximum flexibility—every tool, every option, every possible configuration.
+
+The results are predictable:
+
+- **Sprawl**: Documentation balloons. Teams maintain extensive guides for dozens of alternatives, none of which are cohesive.
+- **Decision fatigue**: Product teams face endless choices with little guidance on what actually works.
+- **Distraction**: Platform teams spend cycles writing documentation instead of understanding customer needs. They lose touch with what's actually frustrating their users.
+- **False satisfaction**: Everyone appears busy, but throughput doesn't improve. The system feels heavy.
+
+The fundamental mistake is treating the platform as a service that should minimize constraints, rather than a service that should maximize value.
+
+## The Shift: Platform as Product
+
+The breakthrough came from a simple reframing: **platform teams should own products, not processes.**
+
+This means:
+
+1. **Sensible defaults over maximum optionality** - If there's no compelling reason not to do something a particular way, do it that way. You get monitoring, alerting, logging, scaling, and observability for free.
+
+2. **Opinionated paths instead of open-ended choices** - The "golden path" isn't a limitation. It's the fastest, most reliable way to accomplish the task. Teams can deviate, but deviating is a decision, not the default.
+
+3. **Active buy vs. build decisions** - Instead of building everything internally, evaluate what genuinely needs to be custom versus what should be purchased or integrated. Many organizations inherit a "build everything" mentality from their startup phase, but that doesn't scale.
+
+This product-focused approach requires a shift in mindset. It means saying "no" to some requests. It means being willing to have opinions. And it means staying close to your users—the engineers and product managers using your platform—to understand what actually helps them move faster.
+
+## Six Principles for Platform Products
+
+To guide this shift, we anchored the platform work in six principles:
+
+**1. Build for Humans**
+This sounds simple but isn't. It means understanding the actual workflows of your users. How do engineers onboard? What frustrates them? What could be smoother? It requires talking to users, embedding in teams, observing their work.
+
+**2. Focus on Impact (Outcome > Output)**
+Measure what matters: Did the change help teams move faster? Did it reduce toil? Did it improve reliability? Not: How many features did we ship?
+
+**3. Build API-First**
+Whether internal tools or infrastructure, design for programmatic access first. This enables other teams to build on top of what you've created. It removes bottlenecks where teams have to wait for manual steps.
+
+**4. Make Quality Your Business**
+Quality isn't something that happens after launch. It's foundational. Tests, observability, monitoring, alerting—these aren't afterthoughts. They're part of what the platform provides for free.
+
+**5. Treat Data as a Product**
+Data that's locked in one system has limited value. Data that's accessible, documented, and discoverable becomes a platform resource. This applies to metrics, logs, events, and structured data alike.
+
+**6. Think Safe & Secure**
+Regulatory requirements, security posture, compliance—these aren't constraints imposed on the platform. They're core to what the platform enables. Teams should be able to build fast *and* safely.
+
+## From Documentation to Implementation
+
+Articulating these principles was a necessary first step. But principles without implementation are just words.
+
+The platform teams created a "How We Build Things" database—essentially a collection of the sensible defaults, golden paths, and best practices, organized around concrete tasks. Instead of generic principles, it documented: "To deploy a service, do X. You get Y for free."
+
+These weren't prescriptive documents trying to cover every edge case. They were products—actual tools, templates, and infrastructure—that implemented the sensible defaults. The documentation explained what you got and why.
+
+The shift from "tell teams how to do things" to "give teams tooling that does the right thing by default" was profound. It meant engineers could adopt the path by simply using the tool, rather than reading extensive documentation and hoping they implemented it correctly.
+
+## Measuring What Matters
+
+How do you know this approach is working? The obvious metrics are throughput and speed:
+
+- **Throughput**: Work completed increased significantly. More PRs shipped. More features deployed.
+- **Cycle time**: Time from idea to production compressed. Average cycle times dropped from over 5 days to around 3 days, with fewer spikes.
+
+But these metrics alone don't tell the full story. The more important signal was that platform teams stopped being a bottleneck. Product teams could move forward independently. Questions got answered. Decisions happened faster. The platform teams weren't context-switching between dozens of enablement requests—they were focused on products that genuinely helped.
+
+## What Worked
+
+- **Product thinking**: Staying close to users, understanding their needs, iterating on solutions based on feedback.
+- **User research**: Even informal—embedding in teams, observing work, doing interviews. Small user populations mean you can do high-touch research.
+- **Sensible defaults with free benefits**: "Do it this way and you get monitoring, alerting, logging, scaling for free" is more powerful than "here are all your options."
+- **Building for concrete needs first, then generalizing**: Start with a specific, real problem. Solve it well. Then abstract the solution.
+- **One clear entry point**: Instead of teams having to figure out which sub-team owns what, create one "front door" and let the platform figure out routing internally.
+
+## What Didn't Work
+
+- **Traditional product management approaches**: Techniques designed for external products with millions of users don't transfer well to internal platforms serving hundreds of engineers. A/B testing, statistical significance, complex experiments—these aren't the right tools for small user populations.
+- **Enablement mentality creeping back in**: It's easy to slip back into "define it and they will obey" thinking. They won't. Compliance through documentation is weak. Compliance through tooling that makes the right thing the easy thing is strong.
+- **Tracking % completion of OKRs**: Moving away from "how much of the OKR did we complete?" to "how confident are we that we'll complete this by end of quarter?" changed the conversation from arguments about estimation to discussions about dependencies and risk.
+
+## Conclusion
+
+Platform engineering isn't about having the most sophisticated tools or the most options. It's about understanding what your internal customers actually need and building products that help them move faster and with more confidence.
+
+The shift from enablement to product doesn't happen overnight. It requires:
+
+- Staying close to your users
+- Being willing to have opinions
+- Building implementation before writing documentation
+- Measuring impact, not output
+- Iterating based on feedback
+
+When you get it right, the platform becomes invisible in the best way—teams stop thinking about it and start thinking about what they're building.


### PR DESCRIPTION
## Summary

Added four draft blog posts and one published post on platform engineering and organizational transformation. Posts cover the shift from enablement-focused to product-focused platform teams, implementation patterns, support meeting dynamics, org restructuring, and measurement strategies without OKR gaming.

## Content

- **Main post**: "From Enablement to Products" - comprehensive overview with 6 guiding principles and results
- **3 draft posts**: Support meetings, org change, and maturity measurements

All posts are objective and generalized, suitable for engineering leadership audiences.

🤖 Generated with Claude Code