### PR TITLE
Add draft post on FinTech partnerships

### DIFF
--- a/content/posts/fintech-partnerships-infrastructure.md
+++ b/content/posts/fintech-partnerships-infrastructure.md
@@ -1,0 +1,58 @@
+---
+title: "The Best Tech Is Not the Best Partner"
+date: 2026-04-22
+draft: true
+tags: ["fintech", "partnerships", "compliance", "leadership"]
+categories: ["Leadership"]
+description: "Why partner selection in FinTech comes down to compliance posture and relationship depth, not which integration looks cleanest."
+---
+
+You're comparing two infrastructure partners. One has the cleaner API, better docs, a sandbox that works on the first try. The other has a compliance function that actually answers the regulator.
+
+Pick the second one.
+
+Tech gaps are engineering problems, bounded and solvable, ugly for a quarter or two. Compliance gaps are existential, and by the time you're feeling them you have no good options left. This is the heuristic I keep coming back to in FinTech partnerships, and it's the one most easily forgotten in a room full of engineers evaluating demos.
+
+## No One Builds the Whole Stack
+
+The structural reality of FinTech is that nobody owns the whole stack. The market is fragmented by vertical, by geography, by license type, by customer segment. Without a license to move money you are renting rails from someone who has one. That's how the industry is shaped, and anyone selling you a full-stack story is usually selling the next acquisition target.
+
+That means partnerships aren't a growth tactic you choose on top of a product you own. They are the product's foundation. Choosing partners well is a first-order problem, on the same level as hiring or pricing. Treating it as a procurement exercise, or delegating it down the org chart, is how teams end up dependent on counterparties they barely understand.
+
+## Compliance Beats Tech
+
+When two partners are close on capability, pick the one with the heavier compliance and regulatory muscle. If their KYC policy looks thinner than yours, if their regulatory team is a single name on a slide, if their answer to "how do you handle a transaction monitoring finding" is vague, that is the signal. Walk away, even if the API is twice as elegant.
+
+The reasoning is straightforward. A tech gap in a partner is a project you can scope. You can route around it, write a wrapper, accept the latency penalty, rebuild on a better counterparty later. None of that is pleasant, but all of it is within engineering's control. A compliance gap can trigger a license event for you, force a migration on a timeline set by someone else's regulator, or quietly poison the book of customers you've acquired through that integration. None of those things are in your control once they start.
+
+This is counter-intuitive for engineering-led teams, which is most FinTech teams. The best-looking demo is often the worst-looking partner. The scruffy provider with a dense compliance manual and a legal team that asks you hard questions is the one you want. They are not scruffy because they are unserious, but because they spent the money on the part that matters.
+
+## When the Partner Moves First
+
+The clearest lesson I've taken from partner selection came from getting it wrong, not right.
+
+We had a large banking partner that handled a meaningful slice of our activity. They were solid, well-known, not anyone's first worry. Then their risk appetite changed. An internal review, a shift in strategy, the specifics did not matter on our end; what mattered was that a segment of our activity was suddenly outside what they would continue to support. We had to migrate it elsewhere, on a timeline we did not control.
+
+The migration itself wasn't the hard part; the hard part was that we hadn't taken ownership of what the partner was doing for us underneath the API. We understood the endpoints. We did not understand the mechanics on their side, the judgement calls they were making on our behalf, the places where their risk policy had been silently shaping our product. When the time came to design the replacement, the design was being made for us by the new counterparty, not by us. We were reconstructing, from the outside, a system we had been depending on without owning.
+
+A partner's risk posture can flip in a quarter. When it does, the only leverage you have is the ownership and understanding you built while things were calm. If the partner is the only one who knows how the money actually moves on your behalf, you don't have a partnership. You have a dependency dressed up as one.
+
+## The Tools Are Not Optional
+
+Once you have more than a handful of partners, the relationship needs maintenance infrastructure. Named contacts for each function, not just a shared inbox. A scorecard per partner that tracks incident response, regulatory posture, and roadmap alignment, not only the commercials. A regulatory-change calendar so nobody is surprised by a license update from a jurisdiction three partners deep. Clear escalation paths so an incident at nine o'clock on a Tuesday evening has a defined answer.
+
+Many FinTech teams treat this as spreadsheet overhead and leave it to whoever has the bandwidth. It is not overhead. Partnerships decay without maintenance, and the decay is invisible until it isn't, usually at the moment someone's risk appetite changes or a regulator sends a letter. The investment in partnership tooling is the investment in not being surprised.
+
+## Someone to Call
+
+The real test of a partnership is not the contract and not the integration. It is the evening something is broken in production and you need a human on the partner's side who understands your customer, understands what you're trying to solve, and will stay on the line until it's resolved. If you cannot name that person today, the partnership doesn't exist yet. You have a contract.
+
+This reshapes what due diligence looks like. The people selling you the deal are not the people you will call. Meet the ones who will own the relationship after the ink dries. Ask who runs the incident bridge on their side, who owns your account in practice, who has the authority to make a call when something ambiguous happens in the middle of the night. If the partner can't answer those questions cleanly, you've learned something important about what happens when you need them.
+
+The best partners I have worked with pass this test easily. The names come quickly, the handoffs are smooth, the first real incident is an exercise in coordination rather than an exercise in figuring out who to escalate to. That isn't luck — it's a partner who has built the same kind of relationship infrastructure on their side that you are trying to build on yours.
+
+## The Kind of Leader Who Builds This
+
+The leaders who are good at this are not the ones with the biggest partner rosters or the slickest integrations. They are the ones who walk away from the better-looking demo when the compliance answer is thin, who maintain real ownership of what the partner is doing on their behalf, and who know the humans on the other side of the API before anything is on fire.
+
+Partnerships aren't infrastructure you procure; they're infrastructure you build, in the relationship, not the integration.


### PR DESCRIPTION
Draft essay on partner selection in FinTech, arguing compliance posture
beats tech capability. Anchored on a risk-appetite-change migration.
Marked draft: true.