### PR TITLE
Polish homepage content and fix rail nav highlight

### DIFF
--- a/src/components/RailClient.tsx
+++ b/src/components/RailClient.tsx
@@ -52,6 +52,11 @@ export default function RailClient() {
 
   useEffect(() => {
     const onScroll = () => {
+      const atBottom = (window.innerHeight + window.scrollY) >= document.body.scrollHeight - 2;
+      if (atBottom) {
+        setActive(SECTION_IDS[SECTION_IDS.length - 1]);
+        return;
+      }
       let best = SECTION_IDS[0];
       let bestTop = -Infinity;
       for (const id of SECTION_IDS) {
@@ -80,7 +85,7 @@ export default function RailClient() {
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline' }}>
           <div>
             <div className="h-display" style={{ fontSize: 22, lineHeight: 1.1 }}>{s.name}</div>
-            <div style={{ fontSize: 13, color: 'var(--ink-60)' }}>{s.role}</div>
+            <div style={{ fontSize: 13, color: 'var(--ink-60)' }}>{s.subtitle}</div>
           </div>
           <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
             <ThemeToggle />
@@ -125,11 +130,8 @@ export default function RailClient() {
           <h1 className="h-display" style={{ fontSize: 30, lineHeight: 1.05, margin: 0 }}>
             {s.name}
           </h1>
-          <div className="h-display" style={{ fontSize: 16, color: 'var(--ink-60)', marginBottom: 4 }}>
-            {s.role}
-          </div>
-          <div className="lbl" style={{ marginBottom: 24 }}>
-            2009 → now · 17 yrs
+          <div style={{ fontSize: 14, color: 'var(--ink-60)', marginBottom: 24, lineHeight: 1.4 }}>
+            {s.subtitle}
           </div>
 
           <div style={{ marginBottom: 28 }}>

--- a/src/data/stefan.ts
+++ b/src/data/stefan.ts
@@ -1,15 +1,16 @@
 export const STEFAN = {
   name: 'Stefan Christensen',
   role: 'SVP Product & Engineering',
+  subtitle: 'Builder of teams. Fixer. Operator.',
   city: 'Copenhagen',
   tagline:
     'Executive operator who scales fintech teams, payment infrastructure, and the organisations around them.',
   longBio: [
-    'I lead platform organisations at growth-stage fintechs — the engine room where payments, infrastructure, risk and developer experience converge. My focus is the boring-but-decisive work of turning a clever product into a company that can take the next ten years.',
-    'Most of my career has been spent in Copenhagen, scaling teams from a handful to hundreds, taking products from early design partners to nine-figure volumes, and rebuilding the operating cadence underneath both. Before that: McKinsey advising Tier 1 European banks, and a PhD in physics building atomic clocks.',
+    'I am a generalist who builds teams and gets things working. At Pleo I built the payments platform from scratch, scaled it across fifteen European markets, and then took on everything around it: data, infrastructure, security, developer experience. When something is broken or missing, I go fix it.',
+    'Most of my career has been in Copenhagen, scaling teams from a handful to hundreds and taking products from early design partners to nine-figure volumes. Before fintech: McKinsey advising Tier 1 European banks, and a PhD in physics building atomic clocks.',
   ],
   short:
-    'I help fintech leaders scale platform teams and the businesses they hold up. Currently SVP Product & Engineering at Pleo; previously McKinsey and a PhD in quantum physics.',
+    'I build and fix platform teams and the businesses they hold up. Currently SVP Product & Engineering at Pleo; previously McKinsey and a PhD in physics.',
   contact: {
     email: 'stefan_christensen@protonmail.com',
     linkedin: 'linkedin.com/in/stefanlchristensen',
@@ -31,7 +32,7 @@ export const STEFAN = {
     },
     {
       label: 'Reading',
-      body: 'Fewer newsletters, more books. Trying to keep the ratio honest.',
+      body: 'Fewer newsletters, more books.',
     },
   ],
   experience: [
@@ -73,11 +74,11 @@ export const STEFAN = {
     },
     {
       title: 'Traditional to AI-first',
-      body: "I'm in the middle of this transition right now — building AI infrastructure at a company that started as a card programme. Not the chatbot layer, but the hard part: rearchitecting data pipelines, compliance automation, and internal tooling so that AI becomes the default way the organisation works. I know what it takes to move a real company, not a greenfield experiment.",
+      body: "I'm in the middle of this transition right now, building AI infrastructure at a company that started as a card programme. Not the chatbot layer, but rearchitecting data pipelines, compliance automation, and internal tooling so that AI becomes the default way the organisation works. I know what it takes to move a real company, not a greenfield experiment.",
     },
     {
       title: 'Scaling platform organisations',
-      body: "Building the engine room — and the operating cadence that keeps it running. Strongest when you're crossing the 50–200 engineer threshold, where the org chart starts to become the product roadmap whether you want it to or not.",
+      body: "Building the teams and operating cadence that keep the platform running. Strongest when you're crossing the 50 to 200 engineer threshold, where org structure starts driving the product roadmap.",
     },
     {
       title: 'Advisory & board',

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -36,7 +36,7 @@ function formatDate(d: Date): string {
         {s.tagline}
       </p>
       <div style="display: flex; flex-wrap: wrap; gap: 8px;">
-        <span class="pill"><b>17 yrs</b> in fintech</span>
+        <span class="pill"><b>~15 yrs</b> in fintech</span>
         <span class="pill"><b>100+</b> engineers led</span>
         <span class="pill"><b>Pleo · McKinsey · Physics</b></span>
         <span class="pill pill--accent">Open to advisory</span>
@@ -47,8 +47,7 @@ function formatDate(d: Date): string {
       <section id="about" class="fade-section">
         <div class="lbl" style="margin-bottom: 16px;">About</div>
         <p style="margin: 0 0 18px;">
-          <span class="dropcap-a">{s.longBio[0].charAt(0)}</span>
-          {s.longBio[0].slice(1)}
+          {s.longBio[0]}
         </p>
         <p style="margin: 0;">{s.longBio[1]}</p>
       </section>
@@ -72,16 +71,16 @@ function formatDate(d: Date): string {
       <section id="work" class="fade-section">
         <div class="lbl" style="margin-bottom: 16px;">The path here</div>
         <p style="margin: 0 0 18px;">
-          I've been at Pleo since 2019, joining at around 100 people to get hands-on after five years advising banks at McKinsey. What started as an operator-in-residence gig — migrating 20,000 customers to a new payment processor, unlocking a 20-point margin uplift — turned into building Pleo's entire payments organisation from scratch. We went from five European markets to fifteen in eleven months.
+          I joined Pleo in 2019 at around 100 people, looking to get hands-on after five years advising banks at McKinsey. My first job was migrating 20,000 customers to a new payment processor and unlocking a 20-point margin uplift. That turned into building the entire payments platform from scratch. We went from five European markets to fifteen in eleven months.
         </p>
         <p style="margin: 0 0 18px;">
-          As the platform matured, the scope grew. I took on data, developer experience, infrastructure, security — eventually leading 100+ people through a period where we tripled engineering throughput without adding headcount. The unlock wasn't more people; it was removing friction and treating platform teams as product teams with real users and real outcomes.
+          As the platform matured, the scope grew. I took on data, developer experience, infrastructure, security, eventually leading 100+ people through a period where we tripled engineering throughput without adding headcount. The unlock was removing friction and treating platform teams as product teams with real users and real outcomes.
         </p>
         <p style="margin: 0 0 18px;">
-          Today I lead ~70 people across platform engineering, data, AI infrastructure, and regulated entities. The recent win I'm proudest of: a 70% reduction in card scheme costs through negotiation in a duopoly market where you have almost no leverage. Execution was everything.
+          Today I lead ~70 people across platform engineering, data, AI infrastructure, and regulated entities. The recent win I'm proudest of: a 70% reduction in card scheme costs through direct negotiation in a duopoly market where you have almost no leverage.
         </p>
         <p style="margin: 0 0 24px;">
-          Before Pleo: McKinsey, advising Tier 1 European banks on payments and regulatory strategy. Before that: a PhD in physics at the University of Copenhagen, building atomic clocks beyond the quantum limit. Different domains, same muscle — solving problems nobody's solved before.
+          Before Pleo: McKinsey, advising Tier 1 European banks on payments and regulatory strategy. Before that: a PhD in physics at the University of Copenhagen, building atomic clocks beyond the quantum limit.
         </p>
         <a class="link" href="/experience/" style="font-size: 14px;">Full experience →</a>
       </section>


### PR DESCRIPTION
## Summary
- Rewrite About bio to emphasize generalist builder/fixer/operator identity and payments platform work ("I am a generalist who builds teams and gets things working")
- Remove AI-sounding language: excessive em-dashes, stock phrases ("boring-but-decisive", "engine room where X converge", "same muscle"), and filler ("trying to keep the ratio honest")
- Remove drop cap (big "I") from About section
- Update rail subtitle from factual "SVP Product & Engineering" + "2009 → now · 17 yrs" to characterful "Builder of teams. Fixer. Operator."
- Fix rail nav not highlighting "Writing" when scrolled to page bottom (added bottom-of-page detection to scroll handler)
- Change "17 yrs" pill to "~15 yrs"

## Test plan
- [ ] Verify homepage loads without errors
- [ ] Scroll to bottom — "Writing" should highlight in left nav
- [ ] Check rail subtitle shows "Builder of teams. Fixer. Operator."
- [ ] Confirm drop cap is gone from About section
- [ ] Read through all text for remaining AI-sounding language

🤖 Generated with [Claude Code](https://claude.com/claude-code)