### PR TITLE
Adjust spacing between page sections

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -42,9 +42,7 @@ function formatDate(d: Date): string {
         ))}
       </div>
 
-      <div class="rule"></div>
-
-      <section id="work" class="fade-section">
+      <section id="work" class="fade-section" style="margin-top: 56px;">
         <h2 class="section-head">The path here</h2>
         <p style="margin: 0 0 18px;">
           I joined Pleo in 2019 at around 100 people, looking to get hands-on after five years advising banks at McKinsey. My first job was migrating 20,000 customers to a new payment processor and unlocking a 20-point margin uplift. That turned into building the entire payments platform from scratch. We went from five European markets to fifteen in eleven months.

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -31,7 +31,7 @@
   --page-pr: 80px;
   --page-pb: 96px;
   --page-pl: 56px;
-  --section-gap: 56px;
+  --section-gap: 40px;
   --rail-width-open: 260px;
   --rail-width-collapsed: 56px;
   --column-gap-open: 64px;


### PR DESCRIPTION
## Summary
Refined the vertical spacing between major page sections to improve visual hierarchy and layout consistency.

## Changes
- Removed the decorative horizontal rule (`<div class="rule"></div>`) that previously separated the skills section from the work section
- Replaced the rule with an explicit `margin-top: 56px;` on the work section for more direct spacing control
- Reduced the global `--section-gap` token from 56px to 40px to create tighter spacing between sections overall

## Implementation Details
The changes consolidate spacing logic by removing a visual separator element and relying instead on CSS margins. This provides more flexibility for future section spacing adjustments while maintaining the visual separation between content areas through whitespace alone.

https://claude.ai/code/session_01NLg6yyVajqH59iv1PSBegn