### PR TITLE
Publish four blog posts to round out the portfolio

### DIFF
--- a/src/content/posts/high-bar-without-burnout.md
+++ b/src/content/posts/high-bar-without-burnout.md
@@ -1,7 +1,7 @@
 ---
 title: "What Setting a High Bar Requires"
 date: 2026-02-26
-draft: true
+draft: false
 tags: ["leadership", "management", "performance", "team-health"]
 categories: ["Leadership"]
 description: "The bar is a contract, not a demand. What it takes to hold high standards and actually help people meet them."

--- a/src/content/posts/physicist-path-to-fintech-leadership.md
+++ b/src/content/posts/physicist-path-to-fintech-leadership.md
@@ -1,7 +1,7 @@
 ---
 title: "The Physicist's Path to FinTech Leadership"
 date: 2026-02-26
-draft: true
+draft: false
 tags: ["career", "physics", "fintech", "leadership", "payments"]
 categories: ["Leadership"]
 description: "The connection between quantum physics and FinTech leadership isn't obvious. But the instincts transfer: systems thinking, order-of-magnitude reasoning, finding the right frame."

--- a/src/content/posts/unglamorous-core-of-payments.md
+++ b/src/content/posts/unglamorous-core-of-payments.md
@@ -1,7 +1,7 @@
 ---
 title: "The Unglamorous Core of Payments"
 date: 2026-04-26
-draft: true
+draft: false
 tags: ["payments", "infrastructure", "settlement", "clearing", "fintech"]
 categories: ["FinTech", "Payments"]
 description: "The smooth checkout is an illusion. The unglamorous infrastructure work behind it is where payments actually live."

--- a/src/content/posts/what-i-listen-to.md
+++ b/src/content/posts/what-i-listen-to.md
@@ -1,7 +1,7 @@
 ---
 title: "What I Listen To"
 date: 2026-03-21
-draft: true
+draft: false
 tags: ["music", "personal"]
 categories: ["Personal"]
 description: "From my father's vinyl to Sufjan Stevens on headphones. The thread is music that doesn't hedge."


### PR DESCRIPTION
## Summary

- **Publishes 4 draft posts** by flipping `draft: true` → `draft: false` in frontmatter
- Takes the site from 4 to 8 published posts, adding range across payments, career, personal, and leadership

## Posts published

1. **The Physicist's Path to FinTech Leadership** — origin story explaining the physics PhD → McKinsey → FinTech arc
2. **The Unglamorous Core of Payments** — signature payments piece on settlement, ledgers, and tracing €29.15
3. **What Setting a High Bar Requires** — leadership post on pair writing as the mechanism for raising standards
4. **What I Listen To** — short personal essay on musical taste and sincerity

## Why these four

The existing portfolio was all leadership/decision-making. These add a career origin story, a deep payments piece, and a personal essay — giving the site a much more complete picture of the author.

## Test plan

- [x] Editorial scan: AI signal check (em dashes, flagged words, closing patterns) — all clean
- [x] `npm run build` succeeds with all 8 posts generated
- [x] Dev server preview: posts listing page shows all 8 posts in correct date order
- [x] Individual post page renders correctly (verified unglamorous-core-of-payments)
- [x] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)