### PR TITLE
Add LinkedIn and Twitter post fields to blog post frontmatter

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -10,6 +10,8 @@ const posts = defineCollection({
     tags: z.array(z.string()).default([]),
     categories: z.array(z.string()).default([]),
     description: z.string().optional(),
+    linkedinPost: z.string().optional(),
+    twitterPost: z.string().optional(),
   }),
 });
 

--- a/src/content/posts/approximations-underrated-in-business.md
+++ b/src/content/posts/approximations-underrated-in-business.md
@@ -5,6 +5,18 @@ draft: false
 tags: ["decision-making", "strategy", "mental-models", "physics"]
 categories: ["Leadership"]
 description: "A physicist's case for approximation as a deliberate tool, and why back-of-envelope thinking beats false precision in business decisions."
+linkedinPost: |
+  We were setting geographic expansion strategy. The "proper" approach would have taken weeks: entity structures, bottom-up market sizing, employee modeling.
+
+  Instead we looked at where the money was already moving. The majority of cross-border volume sat between Europe and the US. That single number made the call. Everything else was a rounding error at that stage.
+
+  The detailed analysis would have arrived at the same answer eventually, and introduced enough complexity to slow it down. Approximation got us there faster, with less noise.
+
+  Most business decisions don't need precision. They need the right order of magnitude, and the confidence to act on it.
+twitterPost: |
+  Most business decisions don't need precision. They need the right order of magnitude.
+
+  When we set our geographic expansion strategy, a back-of-envelope look at the money flows answered it in an afternoon. The full model would have taken weeks and reached the same place.
 ---
 
 The most useful skill in business isn't precision. It's knowing when precision doesn't matter.

--- a/src/content/posts/goal-setting.md
+++ b/src/content/posts/goal-setting.md
@@ -5,6 +5,14 @@ draft: false
 tags: ["leadership", "goal-setting", "organisational-design"]
 categories: ["Leadership"]
 description: "OKRs, SMART, BHAGs, V2MOMs. The framework isn't the point. A goal needs a clear achievement, a baseline, an owner, tangible work you can point to, and a cadence you keep."
+linkedinPost: |
+  OKRs, SMART, BHAGs, V2MOMs. Every year a new framework promises to be the answer.
+
+  What a goal actually needs is unglamorous: a clear achievement, a baseline you can point to, one named owner (a person, not an "area"), tangible deliverables, and a cadence you keep. The frameworks people reach for are ways of arriving at those things. If you already have them, the framework is overhead. If you don't, no framework will give them to you.
+twitterPost: |
+  OKRs, SMART, BHAGs. The framework isn't the point.
+
+  A goal needs a clear achievement, a baseline, one named owner, tangible deliverables, and a cadence you keep. Have those, and the framework is overhead. Don't have them, and no framework will rescue you.
 ---
 
 OKR workshops, SMART goals, BHAGs, MBOs, V2MOMs. Every year there's a new framework that promises to be the answer.

--- a/src/content/posts/high-bar-without-burnout.md
+++ b/src/content/posts/high-bar-without-burnout.md
@@ -5,6 +5,20 @@ draft: false
 tags: ["leadership", "management", "performance", "team-health"]
 categories: ["Leadership"]
 description: "The bar is a contract, not a demand. What it takes to hold high standards and actually help people meet them."
+linkedinPost: |
+  "High standards" is the easy half. The harder half is holding the bar and doing the work alongside the person you're holding to it.
+
+  I had a PM whose documents were written for the meeting, not the reader. Ten bullets, enough to run the room. I tried explaining why it mattered. It didn't land. So we sat down together. Several hours that week, line by line, working through an actual document. Pair writing, like a parent at the kitchen table with a kid's essay.
+
+  The standard became real when they experienced it, not when I argued for it.
+
+  I've erred on the softer side more than I'd like. High standards without support is just pressure wearing a leadership title.
+twitterPost: |
+  The bar is a contract, not a demand.
+
+  Most leaders who think they hold a high bar hold half of one: clear on expectations, less clear on what it takes to help someone meet them.
+
+  High standards without real support is just pressure wearing a leadership title.
 ---
 
 High standards without support is just pressure wearing a leadership title.

--- a/src/content/posts/payment-systems-lessons.md
+++ b/src/content/posts/payment-systems-lessons.md
@@ -5,6 +5,20 @@ draft: false
 tags: ["payments", "infrastructure", "fintech"]
 categories: ["FinTech", "Payments"]
 description: "Payment systems look simple until you hit production. The learning curve is expensive, and most of the lessons live in the gaps between what documentation says and what APIs do."
+linkedinPost: |
+  Payment systems look deceptively simple. Integrate an API, money moves, done.
+
+  Then you hit production. I've watched teams spend weeks, not days, debugging why a ledger wouldn't balance, only to discover a partner was holding funds in an intermediate account nobody had mapped. Three weeks of debugging usually means three days of diagramming were skipped.
+
+  A few other lessons that cost real time to learn. Talk to the partner's engineers, not their account managers. Account managers are incentivised to make things sound simple. Engineers will tell you what actually breaks in production.
+
+  Build for the partner you'll need next, not the one you have. Partners change terms, get acquired, sunset products. Tight coupling turns that into a crisis.
+
+  And know enough about the domain to ask the right questions. A single wrong parameter in a chip card profile can break your product in market. The partner will answer what you ask. They won't fill in what you didn't know to ask.
+twitterPost: |
+  Payment systems look simple until you hit production.
+
+  Lessons that cost real time to learn: diagram every fund movement before you build, talk to partner engineers (not account managers), and know enough about the domain to ask the questions you don't yet know to ask.
 ---
 
 Payment systems look deceptively simple. Integrate an API, money moves, done.

--- a/src/content/posts/physicist-path-to-fintech-leadership.md
+++ b/src/content/posts/physicist-path-to-fintech-leadership.md
@@ -5,6 +5,18 @@ draft: false
 tags: ["career", "physics", "fintech", "leadership", "payments"]
 categories: ["Leadership"]
 description: "The connection between quantum physics and FinTech leadership isn't obvious. But the instincts transfer: systems thinking, order-of-magnitude reasoning, finding the right frame."
+linkedinPost: |
+  Nobody told me a PhD in quantum physics would be useful in FinTech. I had to figure that out by watching the instincts kick in.
+
+  The vocabulary doesn't overlap. The training looks completely different. But the underlying skills transfer: how you approach a hard problem, how you reason under uncertainty, what you do when you're staring at something complicated.
+
+  Three things in particular. Looking for the frame that makes a hard problem tractable before trying to solve it. Comfort with orders of magnitude and the willingness to commit to an approximate answer when more precision wouldn't change the call. Treating architecture like experimental design, where getting the structure right early matters more than moving fast later.
+
+  The lab also held me back in ways I had to correct: too many caveats, too much rigour for situations that needed a recommendation. McKinsey forced that adaptation. The PhD wasn't a detour. It was the lens.
+twitterPost: |
+  Nobody told me a PhD in quantum physics would be useful in FinTech.
+
+  The vocabulary doesn't overlap, but the instincts transfer: finding the frame that makes a hard problem tractable, comfort with orders of magnitude, treating architecture like experimental design.
 ---
 
 Nobody told me a PhD in quantum physics would be useful in FinTech. I had to figure that out myself, mostly by watching the instincts kick in and then realizing where they came from.

--- a/src/content/posts/support-meetings-over-status.md
+++ b/src/content/posts/support-meetings-over-status.md
@@ -5,6 +5,16 @@ draft: false
 tags: ["leadership", "team-dynamics", "meetings", "culture"]
 categories: ["Leadership"]
 description: "A 'status meeting' says your job is to account for yourself. A 'support meeting' says our job is to help you succeed. Same calendar slot, different culture."
+linkedinPost: |
+  A "status meeting" says your job is to account for yourself. A "support meeting" says our job is to help you succeed. Same calendar slot, different culture.
+
+  The most surprising thing about running support meetings wasn't what changed in the meetings. It was what changed between them. People started raising problems earlier, in Slack, in 1:1s, in passing, because the framing had taught them that raising a problem was asking for help, not admitting failure.
+
+  The naming only works if leadership actually behaves like they're there to help. Otherwise it's manipulation, and people see through it fast.
+twitterPost: |
+  A "status meeting" says your job is to account for yourself. A "support meeting" says our job is to help you succeed. Same calendar slot, different culture.
+
+  The real shift happens between the meetings, once people learn it's safe to raise things early.
 ---
 
 A "status meeting" says your job is to account for yourself. A "support meeting" says our job is to help you succeed. Same calendar, same agenda, different culture.

--- a/src/content/posts/unglamorous-core-of-payments.md
+++ b/src/content/posts/unglamorous-core-of-payments.md
@@ -5,6 +5,22 @@ draft: false
 tags: ["payments", "infrastructure", "settlement", "clearing", "fintech"]
 categories: ["FinTech", "Payments"]
 description: "The smooth checkout is an illusion. The unglamorous infrastructure work behind it is where payments actually live."
+linkedinPost: |
+  The customer expected €110.37. What they saw was €81.22.
+
+  The team spent weeks, not days, tracing where €29.15 had gone. Through systems they thought they understood, through partner integrations they'd signed off on, through ledger entries that nearly balanced.
+
+  This is what most of the work in payments actually looks like. Not the smooth checkout. A customer wanting to know why their money looks wrong, and the long quiet effort to give them a real answer.
+
+  The mental model most people carry is wrong. Money doesn't move at the speed of the API call. TIPS has roughly 123 direct participants. T2 sits in the low thousands. Whichever rail you look at, a small core of institutions settles on its own schedule while an enormous population is layered on top.
+
+  The smooth UX is real. The money movement underneath is not. Forgetting which is which is how you end up explaining €29.15 line by line on a Tuesday.
+twitterPost: |
+  The customer expected €110.37. They saw €81.22.
+
+  The team spent weeks tracing €29.15 through six systems, partner integrations, and ledger entries that nearly balanced.
+
+  This is what most of payments actually looks like. Not the smooth checkout. The long effort behind it.
 ---
 
 The customer expected €110.37 in their account. What they saw was €81.22.

--- a/src/content/posts/what-i-listen-to.md
+++ b/src/content/posts/what-i-listen-to.md
@@ -5,6 +5,16 @@ draft: false
 tags: ["music", "personal"]
 categories: ["Personal"]
 description: "From my father's vinyl to Sufjan Stevens on headphones. The thread is music that doesn't hedge."
+linkedinPost: |
+  Most of what I like, I was given before I knew I had a choice.
+
+  My father played records the way other people read. Neil Young, Pink Floyd, Bruce Springsteen. He'd sit through a full side of vinyl without talking. I absorbed more from that than I realized at the time.
+
+  The thread from his records to what I listen to now, mostly Sufjan Stevens on headphones, is music that doesn't hedge. Made by people who put something real into a song and trust you to meet them there. I've never been able to get interested in music designed to be liked.
+twitterPost: |
+  Most of what I like, I was given before I knew I had a choice.
+
+  My father played records the way other people read. The thread from his vinyl to what I listen to now is music that doesn't hedge: made by people who put something real in and trust you to meet them there.
 ---
 
 Most of what I like, I was given before I knew I had a choice.


### PR DESCRIPTION
## Summary
Added support for LinkedIn and Twitter post content in blog post frontmatter, enabling authors to define social media-specific versions of their posts alongside the main article content.

## Changes Made
- **Schema Update** (`src/content.config.ts`): Extended the posts collection schema with two new optional fields:
  - `linkedinPost`: For LinkedIn-specific post content
  - `twitterPost`: For Twitter-specific post content

- **Content Updates**: Added `linkedinPost` and `twitterPost` fields to 9 existing blog posts:
  - `unglamorous-core-of-payments.md`
  - `high-bar-without-burnout.md`
  - `payment-systems-lessons.md`
  - `approximations-underrated-in-business.md`
  - `physicist-path-to-fintech-leadership.md`
  - `support-meetings-over-status.md`
  - `what-i-listen-to.md`
  - `goal-setting.md`

## Implementation Details
- Both fields are optional (`z.string().optional()`), allowing posts to be published without social media variants
- Each post includes tailored content for its respective platform, with LinkedIn posts being more detailed and Twitter posts being more concise
- The fields are positioned in the frontmatter after the existing `description` field for consistency

https://claude.ai/code/session_01C4XmuB3uj1KXbogqQwtZvY