### PR TITLE
Add start-up founder testimonial

### DIFF
--- a/src/data/stefan.ts
+++ b/src/data/stefan.ts
@@ -80,5 +80,10 @@ export const STEFAN = {
         'Stefan is one of the strongest colleagues I have ever worked with. He navigates gnarly migrations, is an excellent org designer, and is a leader everyone wants to follow — because he genuinely cares for every individual on his team.',
       cite: 'VP Engineering, Pleo',
     },
+    {
+      quote:
+        "We were already using AI extensively in our coding, but we knew we'd only scratched the surface. Stefan helped us take the next step — not just by shaping a clear strategy, but by being genuinely hands-on. That credibility was exactly what our development team needed to move past their hesitations and commit to the direction.",
+      cite: 'Start-up founder',
+    },
   ],
 } as const;


### PR DESCRIPTION
## Summary
- Adds a second testimonial to the homepage from a start-up founder, highlighting AI strategy and hands-on credibility with development teams.

## Test plan
- [x] Verified the new quote renders correctly below the existing VP Engineering testimonial
- [x] No console errors
- [x] Dev server builds without issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)